### PR TITLE
Add php-pcov extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN \
   php${PHP_VERSION}-zip \
   php${PHP_VERSION}-intl \
   php${PHP_VERSION}-imagick \
+  php${PHP_VERSION}-pcov \
   imagemagick && apt-get clean
     
 USER www-data

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -26,6 +26,7 @@ RUN yum install -y --enablerepo=remi-php${PHP_VERSION} \
   php-soap \
   php-zip \
   php-intl \
+  php-pcov \
   ImageMagick \
   php-pecl-imagick && yum clean all
 

--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -26,6 +26,7 @@ RUN yum install -y \
   php-soap \
   php-zip \
   php-intl \
+  php-pcov \
   ImageMagick \
   php-pecl-imagick && yum clean all
 


### PR DESCRIPTION
### Description of the Change

This PR adds the php-pcov extension, required by Human Made's S3 Uploads plugin ([here](https://github.com/humanmade/S3-Uploads/blob/3.0.4/composer.json#L30)). Although that is a dev dependency, Composer won't install the plugin if the extension is not present.

### Changelog Entry

Added - php-pcov extension.

### Credits

Props @dustinrue @felipeelia 
