### PR TITLE
Feature/move to ghcr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,13 +29,31 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Github Packages
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          tags: |
+            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
+          images: |
+            ${{ secrets.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}
+
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v4
         with:
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }}
-          tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
 
   Build_PHP_CentOS7:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,21 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.5.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@4
+        uses: docker/metadata-action@4.3.0
         with:
           images: |
             ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
             ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           push: false
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5
+        uses: docker/setup-buildx-action@v2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -29,7 +29,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4
+        uses: docker/build-push-action@v2
         with:
           push: false
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
+            docker.io/${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
             ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
 
       - name: Build and push Docker images
@@ -34,7 +34,6 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@4
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,18 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.5
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@4.3
+        with:
+          images: |
+            ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
+            ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v2.4
         with:
           push: false
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }}
-          tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
 
   Build_PHP_CentOS7_Test:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@4.3
+        uses: docker/metadata-action@4
         with:
           images: |
             ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,21 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
+        uses: docker/setup-buildx-action@v2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@4.3.0
+        uses: docker/metadata-action@4
         with:
           images: |
             ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
             ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v4
         with:
           push: false
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -25,8 +25,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           tags: |
-            type=semver,pattern={{version}},value=${{ matrix.version }}-ubuntu
-            type=semver,pattern={{version}},value=${{ matrix.version }}-ubuntu
+            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           tags: |
             type=semver,pattern={{version}},value=${{ matrix.version }}-ubuntu
+            type=semver,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -24,9 +24,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
+          tags: |
+            type=semver,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
-            docker.io/${{ secrets.IMAGE_NAME }}:${{ matrix.version }}-ubuntu
-            ghcr.io/${{ github.repository }}:${{ matrix.version }}-ubuntu
+            ${{ secrets.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4
@@ -34,6 +36,7 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This image, by itself, is not particularly useful. When run it passes arguments 
 
 ## Building
 
-There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2. Note that we do not build CentOS/Rocky Linux based images beyond 8.0 and they will be removed in the future. Images are available under the tags:
+There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2. Note that we do not build CentOS/Rocky Linux based images beyond 8.0 and they will be removed in the future. 
+
+Also note that CentOS/RL based images are not being pushed to ghcr.io!
+
+Images are available under the tags:
 
 * CentOS 7 based
   * 10up/base-php:5.6 (Deprecated, no longer refreshed)
@@ -19,7 +23,7 @@ There are currently a number of images being built for the different operating s
   * 10up/base-php:7.3 (Deprecated)
   * 10up/base-php:7.4 (Deprecated)
   * 10up/base-php:8.0 (Deprecated)
-* Ubuntu 22.04 based
+* Ubuntu 22.04 based (Docker Hub)
   * 10up/base-php:7.0-ubuntu
   * 10up/base-php:7.1-ubuntu
   * 10up/base-php:7.2-ubuntu
@@ -28,6 +32,15 @@ There are currently a number of images being built for the different operating s
   * 10up/base-php:8.0-ubuntu
   * 10up/base-php:8.1-ubuntu
   * 10up/base-php:8.2-ubuntu
+* Ubuntu 22.04 based (Github Packages)
+  * ghcr.io/10up/base-php:7.0-ubuntu
+  * ghcr.io/10up/base-php:7.1-ubuntu
+  * ghcr.io/10up/base-php:7.2-ubuntu
+  * ghcr.io/10up/base-php:7.3-ubuntu
+  * ghcr.io/10up/base-php:7.4-ubuntu
+  * ghcr.io/10up/base-php:8.0-ubuntu
+  * ghcr.io/10up/base-php:8.1-ubuntu
+  * ghcr.io/10up/base-php:8.2-ubuntu
 
 ## Support Level
 


### PR DESCRIPTION
This is going to cause the base-php package to be pushed to github packages/ghcr.io as well as docker hub in anticipation of docker hub's removal of free accounts