### PR TITLE
Feature/ubuntu2404

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,20 +17,25 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/trunk' }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Github Packages
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,18 +71,18 @@ jobs:
     if: ${{ github.ref == 'refs/heads/trunk' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -87,7 +92,7 @@ jobs:
           echo "REMI_PHP_VERSION=$(echo '${{ matrix.version }}' | sed 's/\.//g')" >> $GITHUB_ENV
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v4
         with:
           push: true
           context: centos7
@@ -105,24 +110,24 @@ jobs:
     if: ${{ github.ref == 'refs/heads/trunk' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v4
         with:
           push: true
           context: centos8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        ubuntu-release-name: ['jammy', 'noble']
     environment:
       name: Build
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/trunk' }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           tags: |
-            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
+            type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
@@ -51,7 +51,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }}
+          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -63,7 +63,6 @@ jobs:
     environment:
       name: Build
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/trunk' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,47 +18,75 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
+      - name: Extract metadata (tags, labels) for Docker (Jammy)
+        if: matrix.ubuntu-release-name == 'jammy'
+        id: meta-jammy
+        uses: docker/metadata-action@v5
         with:
           tags: |
-            type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+              type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+              type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v4
+      - name: Extract metadata (tags, labels) for Docker (Others)
+        if: matrix.ubuntu-release-name != 'jammy'
+        id: meta-others
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+              type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+          images: |
+            ${{ secrets.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images (Jammy)
+        if: matrix.ubuntu-release-name == 'jammy'
+        uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PHP_VERSION=${{ matrix.version }}
+            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          tags: ${{ steps.meta-jammy.outputs.tags }}
+          labels: ${{ steps.meta-jammy.outputs.labels }}
+
+      - name: Build and push Docker images (Others)
+        if: matrix.ubuntu-release-name != 'jammy'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PHP_VERSION=${{ matrix.version }}
+            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          tags: ${{ steps.meta-others.outputs.tags }}
+          labels: ${{ steps.meta-others.outputs.labels }}
 
 
   Build_PHP_CentOS8:
@@ -70,24 +98,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: centos8

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -14,6 +14,11 @@ jobs:
       name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -49,22 +54,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Fixup the PHP version so remi understands it
         run: |
           echo "REMI_PHP_VERSION=$(echo '${{ matrix.version }}' | sed 's/\.//g')" >> $GITHUB_ENV
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v4
         with:
           push: false
           context: centos7
@@ -81,18 +86,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v4
         with:
           push: false
           context: centos8

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -36,7 +36,9 @@ jobs:
         with:
           push: false
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          build-args: |
+            PHP_VERSION=${{ matrix.version }}
+            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,4 +1,4 @@
-name: Build Images
+name: Build Images (Testing)
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           tags: |
-            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
+            type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
@@ -35,7 +35,7 @@ jobs:
         with:
           push: false
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }}
+          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        ubuntu-release-name: ['jammy', 'noble']
     environment:
       name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -21,25 +21,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for Docker (Jammy)
+        if: matrix.ubuntu-release-name == 'jammy'
         id: meta
         uses: docker/metadata-action@v4
         with:
           tags: |
-            type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
-            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
+              type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+              type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
 
-      - name: Set tags
-        id: set-tags
-        run: |
-          if [[ "${{ matrix.ubuntu-release-name }}" == "jammy" ]]; then
-            echo "TAGS=${{ steps.meta.outputs.tags }},${{ matrix.version }}-ubuntu" >> $GITHUB_ENV
-          else
-            echo "TAGS=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-          fi
+      - name: Extract metadata (tags, labels) for Docker (Others)
+        if: matrix.ubuntu-release-name != 'jammy'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          tags: |
+              type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+          images: |
+            ${{ secrets.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -36,9 +36,9 @@ jobs:
         id: set-tags
         run: |
           if [[ "${{ matrix.ubuntu-release-name }}" == "jammy" ]]; then
-            echo "tags=${{ steps.meta.outputs.tags }} ${{ matrix.version }}-ubuntu" >> $GITHUB_ENV
+            echo "TAGS=${{ steps.meta.outputs.tags }},${{ matrix.version }}-ubuntu" >> $GITHUB_ENV
           else
-            echo "tags=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
+            echo "TAGS=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
           fi
 
       - name: Build and push Docker images

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -50,7 +50,9 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          build-args: |
+            PHP_VERSION=${{ matrix.version }}
+            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta-jammy.outputs.tags }}
           labels: ${{ steps.meta-jammy.outputs.labels }}
 
@@ -60,7 +62,9 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          build-args: |
+            PHP_VERSION=${{ matrix.version }}
+            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta-others.outputs.tags }}
           labels: ${{ steps.meta-others.outputs.labels }}
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -51,8 +51,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-jammy.outputs.tags }}
+          labels: ${{ steps.meta-jammy.outputs.labels }}
 
       - name: Build and push Docker images (Others)
         if: matrix.ubuntu-release-name != 'jammy'
@@ -61,8 +61,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-others.outputs.tags }}
+          labels: ${{ steps.meta-others.outputs.labels }}
 
 
   Build_PHP_CentOS8_Test:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -48,7 +48,7 @@ jobs:
         if: matrix.ubuntu-release-name == 'jammy'
         uses: docker/build-push-action@v4
         with:
-          push: true
+          push: false
           platforms: linux/amd64,linux/arm64
           build-args: |
             PHP_VERSION=${{ matrix.version }}
@@ -60,7 +60,7 @@ jobs:
         if: matrix.ubuntu-release-name != 'jammy'
         uses: docker/build-push-action@v4
         with:
-          push: true
+          push: false
           platforms: linux/amd64,linux/arm64
           build-args: |
             PHP_VERSION=${{ matrix.version }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -16,20 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker (Jammy)
         if: matrix.ubuntu-release-name == 'jammy'
         id: meta-jammy
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           tags: |
               type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
@@ -41,7 +41,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker (Others)
         if: matrix.ubuntu-release-name != 'jammy'
         id: meta-others
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           tags: |
               type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push Docker images (Jammy)
         if: matrix.ubuntu-release-name == 'jammy'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: false
           platforms: linux/amd64,linux/arm64
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and push Docker images (Others)
         if: matrix.ubuntu-release-name != 'jammy'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: false
           platforms: linux/amd64,linux/arm64
@@ -83,18 +83,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: false
           context: centos8

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker (Jammy)
         if: matrix.ubuntu-release-name == 'jammy'
-        id: meta
+        id: meta-jammy
         uses: docker/metadata-action@v4
         with:
           tags: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker (Others)
         if: matrix.ubuntu-release-name != 'jammy'
-        id: meta
+        id: meta-others
         uses: docker/metadata-action@v4
         with:
           tags: |
@@ -44,15 +44,24 @@ jobs:
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
 
-      - name: Build and push Docker images
+      - name: Build and push Docker images (Jammy)
+        if: matrix.ubuntu-release-name == 'jammy'
         uses: docker/build-push-action@v4
         with:
-          push: false
+          push: true
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            PHP_VERSION=${{ matrix.version }}
-            UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
-          tags: ${{ env.tags }}
+          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker images (Others)
+        if: matrix.ubuntu-release-name != 'jammy'
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: PHP_VERSION=${{ matrix.version }} UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -27,9 +27,19 @@ jobs:
         with:
           tags: |
             type=raw,pattern={{version}},value=${{ matrix.version }}-${{ matrix.ubuntu-release-name }}
+            type=raw,pattern={{version}},value=${{ matrix.version }}-ubuntu
           images: |
             ${{ secrets.IMAGE_NAME }}
             ghcr.io/${{ github.repository }}
+
+      - name: Set tags
+        id: set-tags
+        run: |
+          if [[ "${{ matrix.ubuntu-release-name }}" == "jammy" ]]; then
+            echo "tags=${{ steps.meta.outputs.tags }} ${{ matrix.version }}-ubuntu" >> $GITHUB_ENV
+          else
+            echo "tags=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
+          fi
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4
@@ -39,7 +49,7 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.version }}
             UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:22.04
+ARG UBUNTU_RELEASE_NAME=jammy
+FROM ubuntu:${UBUNTU_RELEASE_NAME}
 
 ARG PHP_VERSION=8.2
+ARG UBUNTU_RELEASE_NAME=jammy
 
 SHELL ["/bin/bash", "-c"]
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 
 RUN \
   apt-get update && \
@@ -13,10 +16,10 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 RUN \
-  echo "deb https://ppa.launchpadcontent.net/ondrej/php/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/ondrej-ubuntu-php-jammy.list && \
+  echo "deb https://ppa.launchpadcontent.net/ondrej/php/ubuntu/ ${UBUNTU_RELEASE_NAME} main" | tee /etc/apt/sources.list.d/ondrej-ubuntu-php-${UBUNTU_RELEASE_NAME}.list && \
   mkdir ~/.gnupg && chmod 0700 $_ && \
   gpg --no-default-keyring --keyring /usr/share/keyrings/ondrej-ubuntu-php.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 14AA40EC0831756756D7F66C4F4EA0AAE5267A6C && \
-  sed -i 's/deb /deb \[signed\-by=\/usr\/share\/keyrings\/ondrej-ubuntu-php.gpg\] /' /etc/apt/sources.list.d/ondrej-ubuntu-php-jammy.list && \
+  sed -i 's/deb /deb \[signed\-by=\/usr\/share\/keyrings\/ondrej-ubuntu-php.gpg\] /' /etc/apt/sources.list.d/ondrej-ubuntu-php-${UBUNTU_RELEASE_NAME}.list && \
   apt-get update && \
   rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base PHP
 
-This image is the parent for a number of downstream images that make use of PHP either as a commandline tool or for php-fpm. The images are created from a number of base operating systems including CentOS 7, Rocky Linux 8 and Ubuntu. The non-Ubuntu based images are now deprecated and will be replaced with Ubuntu based images over time. This image is meant to be minimal and aims to support the needs of a WordPress ecosystem. The images are offered in both x86_64 and arm64 architectures.
+This image is the parent for a number of downstream images that make use of PHP either as a commandline tool or for php-fpm. The images are created from a number of base operating systems including CentOS 7, Rocky Linux 8 and Ubuntu 22.04 and 24.04. The non-Ubuntu based images are now deprecated and will be replaced with Ubuntu based images over time. This image is meant to be minimal and aims to support the needs of a WordPress ecosystem. The images are offered in both x86_64 and arm64 architectures.
 
 ## Usage
 
@@ -8,7 +8,7 @@ This image, by itself, is not particularly useful. When run it passes arguments 
 
 ## Building
 
-There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2. Note that we do not build CentOS/Rocky Linux based images beyond 8.0 and they will be removed in the future. 
+There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2 and 8.3. Note that we do not build CentOS/Rocky Linux based images beyond 8.1 and they will be removed in the future. 
 
 Also note that CentOS/RL based images are not being pushed to ghcr.io!
 
@@ -23,6 +23,7 @@ Images are available under the tags:
   * 10up/base-php:7.3 (Deprecated)
   * 10up/base-php:7.4 (Deprecated)
   * 10up/base-php:8.0 (Deprecated)
+  * 10up/base-php:8.1 (Deprecated)
 * Ubuntu 22.04 based (Docker Hub)
   * 10up/base-php:7.0-ubuntu
   * 10up/base-php:7.1-ubuntu
@@ -32,6 +33,7 @@ Images are available under the tags:
   * 10up/base-php:8.0-ubuntu
   * 10up/base-php:8.1-ubuntu
   * 10up/base-php:8.2-ubuntu
+  * 10up/base-php:8.3-ubuntu
 * Ubuntu 22.04 based (Github Packages)
   * ghcr.io/10up/base-php:7.0-ubuntu
   * ghcr.io/10up/base-php:7.1-ubuntu
@@ -41,6 +43,27 @@ Images are available under the tags:
   * ghcr.io/10up/base-php:8.0-ubuntu
   * ghcr.io/10up/base-php:8.1-ubuntu
   * ghcr.io/10up/base-php:8.2-ubuntu
+  * ghcr.io/10up/base-php:8.3-ubuntu
+* Ubuntu 24.04 based (Docker Hub)
+  * 10up/base-php:7.0-noble
+  * 10up/base-php:7.1-noble
+  * 10up/base-php:7.2-noble
+  * 10up/base-php:7.3-noble
+  * 10up/base-php:7.4-noble
+  * 10up/base-php:8.0-noble
+  * 10up/base-php:8.1-noble
+  * 10up/base-php:8.2-noble
+  * 10up/base-php:8.3-noble
+* Ubuntu 24.04 based (Github Packages)
+  * ghcr.io/10up/base-php:7.0-noble
+  * ghcr.io/10up/base-php:7.1-noble
+  * ghcr.io/10up/base-php:7.2-noble
+  * ghcr.io/10up/base-php:7.3-noble
+  * ghcr.io/10up/base-php:7.4-noble
+  * ghcr.io/10up/base-php:8.0-noble
+  * ghcr.io/10up/base-php:8.1-noble
+  * ghcr.io/10up/base-php:8.2-noble
+  * ghcr.io/10up/base-php:8.3-noble
 
 ## Support Level
 


### PR DESCRIPTION
Updates a number of actions
Adds support for building a matrix of Ubuntu versions starting with jammy (22.04) and noble (24.04). Jammy images will continue to be tagged as "ubuntu" but also jammy. Noble based images are only tagged with noble.