### PR TITLE
Comments out centos job from the main build and test build actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,37 +88,37 @@ jobs:
           tags: ${{ steps.meta-others.outputs.tags }}
           labels: ${{ steps.meta-others.outputs.labels }}
 
-
-  Build_PHP_CentOS8:
-    strategy:
-      matrix:
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1']
-    environment:
-      name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: centos8
-          platforms: linux/amd64
-          build-args: PHP_VERSION=${{ matrix.version }}
-          tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}
+# CentOS images have been deprecated
+# Build_PHP_CentOS8:
+#   strategy:
+#     matrix:
+#       version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+#   environment:
+#     name: Build
+#   runs-on: ubuntu-latest
+#   steps:
+#     - name: Checkout
+#       uses: actions/checkout@v4
+#       with:
+#         ref: ${{ github.ref }}
+#
+#     - name: Set up QEMU
+#       uses: docker/setup-qemu-action@v3
+#
+#     - name: Set up Docker Buildx
+#       uses: docker/setup-buildx-action@v3
+#
+#     - name: Login to DockerHub
+#       uses: docker/login-action@v3
+#       with:
+#         username: ${{ secrets.DOCKERHUB_USERNAME }}
+#         password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#     - name: Build and push CentOS based Docker images
+#       uses: docker/build-push-action@v6
+#       with:
+#         push: true
+#         context: centos8
+#         platforms: linux/amd64
+#         build-args: PHP_VERSION=${{ matrix.version }}
+#         tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,37 +88,3 @@ jobs:
           tags: ${{ steps.meta-others.outputs.tags }}
           labels: ${{ steps.meta-others.outputs.labels }}
 
-# CentOS images have been deprecated
-# Build_PHP_CentOS8:
-#   strategy:
-#     matrix:
-#       version: ['7.2', '7.3', '7.4', '8.0', '8.1']
-#   environment:
-#     name: Build
-#   runs-on: ubuntu-latest
-#   steps:
-#     - name: Checkout
-#       uses: actions/checkout@v4
-#       with:
-#         ref: ${{ github.ref }}
-#
-#     - name: Set up QEMU
-#       uses: docker/setup-qemu-action@v3
-#
-#     - name: Set up Docker Buildx
-#       uses: docker/setup-buildx-action@v3
-#
-#     - name: Login to DockerHub
-#       uses: docker/login-action@v3
-#       with:
-#         username: ${{ secrets.DOCKERHUB_USERNAME }}
-#         password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#     - name: Build and push CentOS based Docker images
-#       uses: docker/build-push-action@v6
-#       with:
-#         push: true
-#         context: centos8
-#         platforms: linux/amd64
-#         build-args: PHP_VERSION=${{ matrix.version }}
-#         tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -72,32 +72,3 @@ jobs:
             UBUNTU_RELEASE_NAME=${{ matrix.ubuntu-release-name }}
           tags: ${{ steps.meta-others.outputs.tags }}
           labels: ${{ steps.meta-others.outputs.labels }}
-
-# CentOS has been deprecated
-# Build_PHP_CentOS8_Test:
-#   strategy:
-#     matrix:
-#       version: ['7.2', '7.3', '7.4', '8.0', '8.1']
-#   environment:
-#     name: Build
-#   runs-on: ubuntu-latest
-#   steps:
-#     - name: Checkout
-#       uses: actions/checkout@v4
-#       with:
-#         ref: ${{ github.ref }}
-#
-#     - name: Set up QEMU
-#       uses: docker/setup-qemu-action@v3
-#
-#     - name: Set up Docker Buildx
-#       uses: docker/setup-buildx-action@v3
-#
-#     - name: Build and push CentOS based Docker images
-#       uses: docker/build-push-action@v6
-#       with:
-#         push: false
-#         context: centos8
-#         platforms: linux/amd64
-#         build-args: PHP_VERSION=${{ matrix.version }}
-#         tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -73,31 +73,31 @@ jobs:
           tags: ${{ steps.meta-others.outputs.tags }}
           labels: ${{ steps.meta-others.outputs.labels }}
 
-
-  Build_PHP_CentOS8_Test:
-    strategy:
-      matrix:
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1']
-    environment:
-      name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push CentOS based Docker images
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          context: centos8
-          platforms: linux/amd64
-          build-args: PHP_VERSION=${{ matrix.version }}
-          tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}
+# CentOS has been deprecated
+# Build_PHP_CentOS8_Test:
+#   strategy:
+#     matrix:
+#       version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+#   environment:
+#     name: Build
+#   runs-on: ubuntu-latest
+#   steps:
+#     - name: Checkout
+#       uses: actions/checkout@v4
+#       with:
+#         ref: ${{ github.ref }}
+#
+#     - name: Set up QEMU
+#       uses: docker/setup-qemu-action@v3
+#
+#     - name: Set up Docker Buildx
+#       uses: docker/setup-buildx-action@v3
+#
+#     - name: Build and push CentOS based Docker images
+#       uses: docker/build-push-action@v6
+#       with:
+#         push: false
+#         context: centos8
+#         platforms: linux/amd64
+#         build-args: PHP_VERSION=${{ matrix.version }}
+#         tags: ${{ secrets.IMAGE_NAME }}:${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base PHP
 
-This image is the parent for a number of downstream images that make use of PHP either as a commandline tool or for php-fpm. The images are created from a number of base operating systems including CentOS 7, Rocky Linux 8 and Ubuntu 22.04 and 24.04. The non-Ubuntu based images are now deprecated and will be replaced with Ubuntu based images over time. This image is meant to be minimal and aims to support the needs of a WordPress ecosystem. The images are offered in both x86_64 and arm64 architectures.
+This image is the parent for a number of downstream images that make use of PHP either as a commandline tool or for php-fpm. The images are created from a number of base operating systems including Rocky Linux 8 and Ubuntu 22.04 and 24.04. The non-Ubuntu based images are now deprecated and will be replaced with Ubuntu based images over time. This image is meant to be minimal and aims to support the needs of a WordPress ecosystem. The images are offered in both x86_64 and arm64 architectures.
 
 ## Usage
 
@@ -8,7 +8,7 @@ This image, by itself, is not particularly useful. When run it passes arguments 
 
 ## Building
 
-There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4. Note that we do not build CentOS/Rocky Linux based images beyond 8.1 and they will be removed in the future. 
+There are currently a number of images being built for the different operating systems. This image is built with support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4. Note that we do not build Rocky Linux based images beyond 8.1 and they will be removed in the future. 
 
 Also note that CentOS/RL based images are not being pushed to ghcr.io!
 


### PR DESCRIPTION
### Description of the Change
Since CentOS is no longer in use, this PR comments out the CentOS jobs from both build actions. I elected to simply comment out the jobs in case we want to enable them again in the future.

Successful Job: https://github.com/10up/base-php/actions/runs/16574639135

### How to test the Change
Build the container

### Changelog Entry
- Comments out centos job from the main build and test build actions

### Credits
Thanks @dustinrue 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [NA] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
